### PR TITLE
bump compat for "StructArrays" to "0.5"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ FixedPointNumbers = "0.6, 0.7, 0.8"
 GeometryBasics = "0.2, 0.3"
 Observables = "0.2, 0.3"
 StaticArrays = "0.11, 0.12, 1.0"
-StructArrays = "0.3.0, 0.4"
+StructArrays = "0.3.0, 0.4, 0.5"
 Tables = "0.2, 1"
 julia = "1"
 


### PR DESCRIPTION
StructArrays v0.5 is a compat requirement for GeometryBasics v0.3.11